### PR TITLE
fix the "--installargs" parameter by using "--ia" instead of "-ia"

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -82,8 +82,8 @@ end
 
 def cmd_args
   output = ''
-  output += " -source #{@current_resource.source}" if @current_resource.source
-  output += " --ia '#{@current_resource.args}'" unless @current_resource.args.to_s.empty?
+  output += " --source #{@current_resource.source}" if @current_resource.source
+  output += " --installargs '#{@current_resource.args}'" unless @current_resource.args.to_s.empty?
   @current_resource.options.each do |k, v|
     output += " -#{k}"
     output += " #{v}" if v

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -83,7 +83,7 @@ end
 def cmd_args
   output = ''
   output += " -source #{@current_resource.source}" if @current_resource.source
-  output += " -ia '#{@current_resource.args}'" unless @current_resource.args.to_s.empty?
+  output += " --ia '#{@current_resource.args}'" unless @current_resource.args.to_s.empty?
   @current_resource.options.each do |k, v|
     output += " -#{k}"
     output += " #{v}" if v


### PR DESCRIPTION
### Description

"-ia" does not seem to be accepted by newer choco versions, but "--ia" does

See Chocolatey commandline reference:
https://github.com/chocolatey/choco/wiki/CommandsInstall

The docs say:

> In most cases you can still pass options and switches with one dash (-).

It seems for "-ia" this is not the case and you have to use "--ia"

### Issues Resolved

no issue created for this 

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
